### PR TITLE
Fix error message when Overseer task is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ require("cmake-tools").setup {
             strategy = {
                 "toggleterm",
                 direction = "horizontal",
-                autos_croll = true,
+                auto_scroll = true,
                 quit_on_exit = "success"
             }
         }, -- options to pass into the `overseer.new_task` command

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -258,6 +258,9 @@ end
 
 function Config:get_launch_target_from_info(target_info)
   local target_path = target_info["artifacts"][1]["path"]
+  if require('cmake-tools.osys').iswin32 then
+    target_path = target_path:gsub("/", "\\")
+  end
   target_path = Path:new(target_path)
   if not target_path:is_absolute() then
     -- then it is a relative path, based on build directory

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -258,7 +258,7 @@ end
 
 function Config:get_launch_target_from_info(target_info)
   local target_path = target_info["artifacts"][1]["path"]
-  if require('cmake-tools.osys').iswin32 then
+  if require("cmake-tools.osys").iswin32 then
     target_path = target_path:gsub("/", "\\")
   end
   target_path = Path:new(target_path)

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -364,6 +364,10 @@ function cmake.build(opt, callback)
     vim.list_extend(args, fargs)
   end
 
+  if config.build_type ~= nil then
+    vim.list_extend(args, { "--config", config.build_type })
+  end
+
   vim.list_extend(args, config:build_options())
 
   local env = environment.get_build_environment(config)

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -1403,7 +1403,7 @@ function cmake.create_regenerate_on_save_autocmd()
 
   local cwd = config.cwd
   if require("cmake-tools.osys").iswin32 then
-      cwd = config.cwd:gsub("\\", "/")
+    cwd = config.cwd:gsub("\\", "/")
   end
 
   local presets_exists = config.base_settings.use_preset and Presets.exists(config.cwd)

--- a/lua/cmake-tools/overseer.lua
+++ b/lua/cmake-tools/overseer.lua
@@ -50,9 +50,9 @@ end
 function _overseer.has_active_job(opts)
   if _overseer.job ~= nil and _overseer.job:is_running() then
     log.error(
-      "A CMake task is already running: "
-        .. _overseer.job.command
-        .. " Stop it before trying to run a new CMake task."
+      "A CMake task is already running: `"
+        .. (_overseer.job.name or _overseer.job.cmd)
+        .. "` Stop it before trying to run a new CMake task."
     )
     return true
   end

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -532,6 +532,7 @@ local get_command_handling_on_exit = function()
 
   local exit_op = "$?"
   local escape_rm = " \\rm -f "
+  local and_op = " &&"
 
   if is_fish_shell() then
     exit_op = "$status"
@@ -540,12 +541,13 @@ local get_command_handling_on_exit = function()
 
   if osys.iswin32 then
     exit_op = is_power_shell() and "$LASTEXITCODE" or "%errorlevel%"
+    and_op = is_power_shell() and " -and" or " &&"
     escape_rm = is_power_shell() and " Remove-Item " or " del /Q "
     exit_code_file_path = exit_code_file_path:gsub("/", "\\")
     lock_file_path = lock_file_path:gsub("/", "\\")
   end
 
-  return "echo " .. exit_op .. " > " .. exit_code_file_path .. " &&" .. escape_rm .. lock_file_path
+  return "echo " .. exit_op .. " > " .. exit_code_file_path .. and_op .. escape_rm .. lock_file_path
 end
 
 ---tries to read the number stored in get_last_exit_code_file_path() file

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -573,9 +573,6 @@ function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
     -- Escape all special pattern characters
     local escapedCwd = cwd:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
     cmd = cmd:gsub(escapedCwd, osys.iswin32 and ".\\" or "./")
-    if osys.iswin32 then
-      cmd = cmd:gsub("/", "\\")
-    end
     cwd = utils.transform_path(cwd)
     local envTbl = {}
     local fmtStr = osys.iswin32 and "set %s=%s" or "%s=%s"

--- a/lua/cmake-tools/terminal.lua
+++ b/lua/cmake-tools/terminal.lua
@@ -573,6 +573,9 @@ function _terminal.run(cmd, env_script, env, args, cwd, opts, on_exit, on_output
     -- Escape all special pattern characters
     local escapedCwd = cwd:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
     cmd = cmd:gsub(escapedCwd, osys.iswin32 and ".\\" or "./")
+    if osys.iswin32 then
+      cmd = cmd:gsub("/", "\\")
+    end
     cwd = utils.transform_path(cwd)
     local envTbl = {}
     local fmtStr = osys.iswin32 and "set %s=%s" or "%s=%s"

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -188,6 +188,10 @@ function utils.run(cmd, env_script, env, args, cwd, runner, callback)
   -- save all
   vim.cmd("silent exec " .. '"wall"')
 
+  if osys.iswin32 then
+    cmd = cmd:gsub('/', '\\')
+  end
+
   local ntfy = notification:new("runner")
 
   ntfy:notify(cmd, "info")

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -189,7 +189,7 @@ function utils.run(cmd, env_script, env, args, cwd, runner, callback)
   vim.cmd("silent exec " .. '"wall"')
 
   if osys.iswin32 then
-    cmd = cmd:gsub('/', '\\')
+    cmd = cmd:gsub("/", "\\")
   end
 
   local ntfy = notification:new("runner")

--- a/lua/cmake-tools/utils.lua
+++ b/lua/cmake-tools/utils.lua
@@ -188,10 +188,6 @@ function utils.run(cmd, env_script, env, args, cwd, runner, callback)
   -- save all
   vim.cmd("silent exec " .. '"wall"')
 
-  if osys.iswin32 then
-    cmd = cmd:gsub("/", "\\")
-  end
-
   local ntfy = notification:new("runner")
 
   ntfy:notify(cmd, "info")


### PR DESCRIPTION
- **fix(windows): Fixed cmake run command using forward instead of backslashes**
- **Patch cmd before it reaches the runners**
- **Fixed quotes**
- **Fixed actual root cause of bug**
- **Update lua/cmake-tools/config.lua**
- **fix(windows): Fix powershell legacy and operator (&&)**
- **fix: pass config argument to build process for multiconfig generators**
- **typo in README.md**
- **fix: Fix error message when Overseer is running a job**
