### PR TITLE
Add cmake_sync_build_and_launch_targets option

### DIFF
--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -13,6 +13,7 @@ local Config = {
   variant = nil,
   build_target = nil,
   launch_target = nil,
+  sync_targets = false,
   kit = nil,
   configure_preset = nil,
   build_preset = nil,
@@ -46,6 +47,7 @@ function Config:new(const)
 
   obj.executor = const.cmake_executor
   obj.runner = const.cmake_runner
+  obj.sync_targets = const.cmake_sync_build_and_launch_targets
 
   return obj
 end

--- a/lua/cmake-tools/config.lua
+++ b/lua/cmake-tools/config.lua
@@ -365,11 +365,12 @@ function Config:validate_for_debugging()
 end
 
 local function get_targets(config, opt)
-  local targets, display_targets, paths, abs_paths = {}, {}, {}, {}
+  local targets, display_targets, types, paths, abs_paths = {}, {}, {}, {}, {}
   local sources = {}
   if opt.has_all then
     table.insert(targets, "all")
     table.insert(display_targets, "all")
+    table.insert(types, nil)
   end
   local codemodel_targets = config:get_codemodel_targets()
   if codemodel_targets.code ~= Types.SUCCESS then
@@ -396,11 +397,13 @@ local function get_targets(config, opt)
         if target_name == config.build_target then
           table.insert(targets, 1, target_name)
           table.insert(display_targets, 1, display_name)
+          table.insert(types, 1, type)
           table.insert(paths, 1, path)
           table.insert(abs_paths, 1, abs_path)
         else
           table.insert(targets, target_name)
           table.insert(display_targets, display_name)
+          table.insert(types, type)
           table.insert(paths, path)
           table.insert(abs_paths, abs_path)
         end
@@ -421,6 +424,7 @@ local function get_targets(config, opt)
     return Result:new(Types.SUCCESS, {
       targets = targets,
       display_targets = display_targets,
+      types = types,
       paths = paths,
       abs_paths = abs_paths,
       sources = sources,
@@ -428,7 +432,7 @@ local function get_targets(config, opt)
   else
     return Result:new(
       Types.SUCCESS,
-      { targets = targets, display_targets = display_targets, paths = paths, abs_paths = abs_paths },
+      { targets = targets, display_targets = display_targets, types = types, paths = paths, abs_paths = abs_paths },
       "Success!"
     )
   end

--- a/lua/cmake-tools/const.lua
+++ b/lua/cmake-tools/const.lua
@@ -134,6 +134,7 @@ local const = {
     refresh_rate_ms = 100, -- how often to iterate icons
   },
   cmake_virtual_text_support = true, -- Show the target related to current file using virtual text (at right corner)
+  cmake_sync_build_and_launch_targets = false, -- if true, selecting a build target also sets it as the launch target (when executable) and vice versa
 }
 
 return const

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -886,16 +886,8 @@ function cmake.select_build_target(regenerate, callback)
         return
       end
       config.build_target = targets[idx]
-      if config.sync_targets then
-        local launch_res = config:launch_targets()
-        if launch_res.code == Types.SUCCESS then
-          for _, lt in ipairs(launch_res.data.targets) do
-            if lt == targets[idx] then
-              config.launch_target = targets[idx]
-              break
-            end
-          end
-        end
+      if config.sync_targets and display_targets[idx] and display_targets[idx]:find("%(executable%)") then
+        config.launch_target = targets[idx]
       end
       callback(Result:new(Types.SUCCESS, config.build_target, nil))
     end)

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -876,7 +876,8 @@ function cmake.select_build_target(regenerate, callback)
       end)
     end
   end
-  local targets, display_targets = targets_res.data.targets, targets_res.data.display_targets
+  local targets, display_targets, types =
+    targets_res.data.targets, targets_res.data.display_targets, targets_res.data.types
   vim.ui.select(
     display_targets,
     { prompt = "Select build target" },
@@ -886,7 +887,7 @@ function cmake.select_build_target(regenerate, callback)
         return
       end
       config.build_target = targets[idx]
-      if config.sync_targets and display_targets[idx] and display_targets[idx]:find("%(executable%)") then
+      if config.sync_targets and types[idx] == "executable" then
         config.launch_target = targets[idx]
       end
       callback(Result:new(Types.SUCCESS, config.build_target, nil))

--- a/lua/cmake-tools/init.lua
+++ b/lua/cmake-tools/init.lua
@@ -886,6 +886,17 @@ function cmake.select_build_target(regenerate, callback)
         return
       end
       config.build_target = targets[idx]
+      if config.sync_targets then
+        local launch_res = config:launch_targets()
+        if launch_res.code == Types.SUCCESS then
+          for _, lt in ipairs(launch_res.data.targets) do
+            if lt == targets[idx] then
+              config.launch_target = targets[idx]
+              break
+            end
+          end
+        end
+      end
       callback(Result:new(Types.SUCCESS, config.build_target, nil))
     end)
   )
@@ -946,6 +957,9 @@ function cmake.select_launch_target(regenerate, callback)
         return
       end
       config.launch_target = targets[idx]
+      if config.sync_targets then
+        config.build_target = targets[idx]
+      end
       callback(Result:new(Types.SUCCESS, config.launch_target, nil))
     end)
   )


### PR DESCRIPTION
When enabled, selecting a build target automatically sets the launch
target to the same target if it is executable, and selecting a launch
target automatically sets the build target to the same target.

https://claude.ai/code/session_01WpgY998njHvRGLTBNWAXoF